### PR TITLE
Update irrigation towers for Timberborn 1.1 UI

### DIFF
--- a/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/BigIrrigationTower.Emberpelts.blueprint.json
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/BigIrrigationTower.Emberpelts.blueprint.json
@@ -992,16 +992,20 @@
     "UnblockedCoordinates": [],
     "BlockedEdges": []
   },
-  "DrivewayModelSpec": {
-    "Driveway": "WideCenter",
-    "HasCustomCoordinates": true,
-    "CustomCoordinates": {
-      "X": 3,
-      "Y": 0,
-      "Z": 0
-    },
-    "CustomDirection": "Down",
-    "DrivewayMode": "Unidirectional"
+  "DrivewayModelsSpec": {
+    "Driveways": [
+      {
+        "Driveway": "WideCenter",
+        "HasCustomCoordinates": true,
+        "CustomCoordinates": {
+          "X": 3,
+          "Y": 0,
+          "Z": 0
+        },
+        "CustomDirection": "Down",
+        "DrivewayMode": "Unidirectional"
+      }
+    ]
   },
   "TransputProviderSpec": {
     "Transputs": [

--- a/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/BigIrrigationTower.Folktails.blueprint.json
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/BigIrrigationTower.Folktails.blueprint.json
@@ -992,16 +992,20 @@
     "UnblockedCoordinates": [],
     "BlockedEdges": []
   },
-  "DrivewayModelSpec": {
-    "Driveway": "WideCenter",
-    "HasCustomCoordinates": true,
-    "CustomCoordinates": {
-      "X": 3,
-      "Y": 0,
-      "Z": 0
-    },
-    "CustomDirection": "Down",
-    "DrivewayMode": "Unidirectional"
+  "DrivewayModelsSpec": {
+    "Driveways": [
+      {
+        "Driveway": "WideCenter",
+        "HasCustomCoordinates": true,
+        "CustomCoordinates": {
+          "X": 3,
+          "Y": 0,
+          "Z": 0
+        },
+        "CustomDirection": "Down",
+        "DrivewayMode": "Unidirectional"
+      }
+    ]
   },
   "TransputProviderSpec": {
     "Transputs": [

--- a/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/BigIrrigationTower.IronTeeth.blueprint.json
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/BigIrrigationTower.IronTeeth.blueprint.json
@@ -992,16 +992,20 @@
     "UnblockedCoordinates": [],
     "BlockedEdges": []
   },
-  "DrivewayModelSpec": {
-    "Driveway": "WideCenter",
-    "HasCustomCoordinates": true,
-    "CustomCoordinates": {
-      "X": 3,
-      "Y": 0,
-      "Z": 0
-    },
-    "CustomDirection": "Down",
-    "DrivewayMode": "Unidirectional"
+  "DrivewayModelsSpec": {
+    "Driveways": [
+      {
+        "Driveway": "WideCenter",
+        "HasCustomCoordinates": true,
+        "CustomCoordinates": {
+          "X": 3,
+          "Y": 0,
+          "Z": 0
+        },
+        "CustomDirection": "Down",
+        "DrivewayMode": "Unidirectional"
+      }
+    ]
   },
   "TransputProviderSpec": {
     "Transputs": [

--- a/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/IrrigationTowerV2.Emberpelts.blueprint.json
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/IrrigationTowerV2.Emberpelts.blueprint.json
@@ -258,10 +258,8 @@
   "ModifyGrowableGrowthRangeEffectSpec": {
     "EffectGroup": "ModifyGrowthRate",
     "GrowthRateModifier": 20.0,
-    "ComponentsFilter": [
-      ""
-    ],
-    "PrefabNamesFilter": []
+    "ComponentsFilter": [],
+    "TemplateNamesFilter": []
   },
   "Children": {
     "#Finished": {

--- a/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/IrrigationTowerV2.Folktails.blueprint.json
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Knatte/Buildings/Water/Irrigation/IrrigationTowerV2.Folktails.blueprint.json
@@ -258,10 +258,8 @@
   "ModifyGrowableGrowthRangeEffectSpec": {
     "EffectGroup": "ModifyGrowthRate",
     "GrowthRateModifier": 20.0,
-    "ComponentsFilter": [
-      ""
-    ],
-    "PrefabNamesFilter": []
+    "ComponentsFilter": [],
+    "TemplateNamesFilter": []
   },
   "Children": {
     "#Finished": {

--- a/Assets/Mods/Water Extention_Irrigation/Data/Localizations/deDE.csv
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Localizations/deDE.csv
@@ -2,27 +2,17 @@ ID,Text,Comment
 Knatte.WE_IrrigationExtractFuel.DisplayName,Bewässerung mit Baumwachstumsförderung,
 Knatte.WE_IrrigationFuel.DisplayName,Bewässerung,
 Knatte.IrrigationTower.DisplayName,Bewässerungsturm,-
-Knatte.IrrigationTower.Description,"Bewässert umliegende Fläche. 
-Verbraucht kein Wasser für Flächen, die nicht bewässert werden können.
-Max range: 7",
+Knatte.IrrigationTower.Description,"Bewässert umliegende Fläche.",
 Knatte.IrrigationTower.Header,Irrigation Mode:,untranslated
 Knatte.IrrigationTower.FlavorDescription,"Da weniger als ein Drittel der Erde mit Wasser bedeckt ist, wurde die Bewässerung zu einem Muss.","Das Spiel findet auf der Erde statt, die sich in ein trockenes Ödland verwandelt hat."
 Knatte.IrrigationTowerV2_FT.DisplayName,Effizienter Bewässerungsturm,-
-Knatte.IrrigationTowerV2_FT.Description,"Irrigates More land around it and can boost tree and plant growth with extract.
-Does not use water for tiles that it can't Irrigate 
-Max range: 15",
+Knatte.IrrigationTowerV2_FT.Description,"Irrigates more land around it and can boost tree and plant growth with extract.",
 Knatte.IrrigationTowerV2_IT.DisplayName,Energiebetriebener Bewässerungsturm,-
-Knatte.IrrigationTowerV2_IT.Description,"Bewässert umliegende Fläche, ohne dass ein Arbeiter benötigt wird. Für mehr Wasserverbrauch stoppt es auch Kontaminierung.
-Verbraucht kein Wasser für Flächen, die nicht bewässert werden können. 
-Max range: 17",
+Knatte.IrrigationTowerV2_IT.Description,"Bewässert umliegende Fläche, ohne dass ein Arbeiter benötigt wird. Für mehr Wasserverbrauch stoppt es auch Kontaminierung.",
 Knatte.IrrigationTowerV2.FlavorDescription,"Da weniger als ein Drittel der Erde mit Wasser bedeckt ist, wurde die Bewässerung zu einem Muss.","Das Spiel findet auf der Erde statt, die sich in ein trockenes Ödland verwandelt hat."
 Knatte.BigIrrigationTower.DisplayName,Großer Bewässerungsturm,-
-Knatte.BigIrrigationTowerIT.Description,"Irrigates even More land around it for less Water. 
-Pipes is the starting point of irrigation. 
-Does not use water for tiles that it cant Irrigate
-Max range: 40",
-Knatte.BigIrrigationTowerFT.Description,"Irrigates even More land around it for less Water. 
-Pipes is the starting point of irrigation.
-Does not use water for tiles that it cant Irrigate
-Max range: 40",
+Knatte.BigIrrigationTowerIT.Description,"Irrigates even more land around it with less water.
+Pipes are the starting point of irrigation.",
+Knatte.BigIrrigationTowerFT.Description,"Irrigates even more land around it with less water.
+Pipes are the starting point of irrigation.",
 Knatte.BigIrrigationTower.FlavorDescription,"Tropf, tropf, Wassertropfen.",-

--- a/Assets/Mods/Water Extention_Irrigation/Data/Localizations/deDE.csv
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Localizations/deDE.csv
@@ -6,13 +6,13 @@ Knatte.IrrigationTower.Description,"Bewässert umliegende Fläche.",
 Knatte.IrrigationTower.Header,Irrigation Mode:,untranslated
 Knatte.IrrigationTower.FlavorDescription,"Da weniger als ein Drittel der Erde mit Wasser bedeckt ist, wurde die Bewässerung zu einem Muss.","Das Spiel findet auf der Erde statt, die sich in ein trockenes Ödland verwandelt hat."
 Knatte.IrrigationTowerV2_FT.DisplayName,Effizienter Bewässerungsturm,-
-Knatte.IrrigationTowerV2_FT.Description,"Irrigates more land around it and can boost tree and plant growth with extract.",
+Knatte.IrrigationTowerV2_FT.Description,"Irrigates More land around it and can boost tree and plant growth with extract.",
 Knatte.IrrigationTowerV2_IT.DisplayName,Energiebetriebener Bewässerungsturm,-
 Knatte.IrrigationTowerV2_IT.Description,"Bewässert umliegende Fläche, ohne dass ein Arbeiter benötigt wird. Für mehr Wasserverbrauch stoppt es auch Kontaminierung.",
 Knatte.IrrigationTowerV2.FlavorDescription,"Da weniger als ein Drittel der Erde mit Wasser bedeckt ist, wurde die Bewässerung zu einem Muss.","Das Spiel findet auf der Erde statt, die sich in ein trockenes Ödland verwandelt hat."
 Knatte.BigIrrigationTower.DisplayName,Großer Bewässerungsturm,-
-Knatte.BigIrrigationTowerIT.Description,"Irrigates even more land around it with less water.
-Pipes are the starting point of irrigation.",
-Knatte.BigIrrigationTowerFT.Description,"Irrigates even more land around it with less water.
-Pipes are the starting point of irrigation.",
+Knatte.BigIrrigationTowerIT.Description,"Irrigates even More land around it for less Water.
+Pipes is the starting point of irrigation.",
+Knatte.BigIrrigationTowerFT.Description,"Irrigates even More land around it for less Water.
+Pipes is the starting point of irrigation.",
 Knatte.BigIrrigationTower.FlavorDescription,"Tropf, tropf, Wassertropfen.",-

--- a/Assets/Mods/Water Extention_Irrigation/Data/Localizations/enUS.csv
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Localizations/enUS.csv
@@ -2,27 +2,17 @@ ID,Text,Comment
 Knatte.WE_IrrigationExtractFuel.DisplayName,Irrigation With Tree boost,
 Knatte.WE_IrrigationFuel.DisplayName,Irrigation,
 Knatte.IrrigationTower.DisplayName,Irrigation Tower,-
-Knatte.IrrigationTower.Description,"Irrigates land around it. 
-Does not use water for tiles that it can't Irrigate
-Max range: 7",
+Knatte.IrrigationTower.Description,"Irrigates land around it.",
 Knatte.IrrigationTower.Header,Irrigation Mode:,
 Knatte.IrrigationTower.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
 Knatte.IrrigationTowerV2_FT.DisplayName,Efficient Irrigation Tower,-
-Knatte.IrrigationTowerV2_FT.Description,"Irrigates More land around it and can boost tree and plant growth with extract.
-Does not use water for tiles that it can't Irrigate 
-Max range: 15",
+Knatte.IrrigationTowerV2_FT.Description,"Irrigates more land around it and can boost tree and plant growth with extract.",
 Knatte.IrrigationTowerV2_IT.DisplayName,Powered Irrigation Tower,-
-Knatte.IrrigationTowerV2_IT.Description,"Irrigates around it without any worker needed. For more Water usage it also blocks contamination.
-Does not use water for tiles that it can't Irrigate 
-Max range: 17",
+Knatte.IrrigationTowerV2_IT.Description,"Irrigates land around it without workers and can block contamination.",
 Knatte.IrrigationTowerV2.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
 Knatte.BigIrrigationTower.DisplayName,Big Irrigation Tower,-
-Knatte.BigIrrigationTowerIT.Description,"Irrigates even More land around it for less Water. 
-Pipes is the starting point of irrigation.
-Does not use water for tiles that it cant Irrigate
-Max range: 40",
-Knatte.BigIrrigationTowerFT.Description,"Irrigates even More land around it for less Water. 
-Pipes is the starting point of irrigation.
-Does not use water for tiles that it cant Irrigate
-Max range: 40",
+Knatte.BigIrrigationTowerIT.Description,"Irrigates even more land around it with less water.
+Pipes are the starting point of irrigation.",
+Knatte.BigIrrigationTowerFT.Description,"Irrigates even more land around it with less water.
+Pipes are the starting point of irrigation.",
 Knatte.BigIrrigationTower.FlavorDescription,Drip Drip Drop.,

--- a/Assets/Mods/Water Extention_Irrigation/Data/Localizations/enUS.csv
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Localizations/enUS.csv
@@ -6,13 +6,13 @@ Knatte.IrrigationTower.Description,"Irrigates land around it.",
 Knatte.IrrigationTower.Header,Irrigation Mode:,
 Knatte.IrrigationTower.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
 Knatte.IrrigationTowerV2_FT.DisplayName,Efficient Irrigation Tower,-
-Knatte.IrrigationTowerV2_FT.Description,"Irrigates more land around it and can boost tree and plant growth with extract.",
+Knatte.IrrigationTowerV2_FT.Description,"Irrigates More land around it and can boost tree and plant growth with extract.",
 Knatte.IrrigationTowerV2_IT.DisplayName,Powered Irrigation Tower,-
-Knatte.IrrigationTowerV2_IT.Description,"Irrigates land around it without workers and can block contamination.",
+Knatte.IrrigationTowerV2_IT.Description,"Irrigates around it without any worker needed. For more Water usage it also blocks contamination.",
 Knatte.IrrigationTowerV2.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
 Knatte.BigIrrigationTower.DisplayName,Big Irrigation Tower,-
-Knatte.BigIrrigationTowerIT.Description,"Irrigates even more land around it with less water.
-Pipes are the starting point of irrigation.",
-Knatte.BigIrrigationTowerFT.Description,"Irrigates even more land around it with less water.
-Pipes are the starting point of irrigation.",
+Knatte.BigIrrigationTowerIT.Description,"Irrigates even More land around it for less Water.
+Pipes is the starting point of irrigation.",
+Knatte.BigIrrigationTowerFT.Description,"Irrigates even More land around it for less Water.
+Pipes is the starting point of irrigation.",
 Knatte.BigIrrigationTower.FlavorDescription,Drip Drip Drop.,

--- a/Assets/Mods/Water Extention_Irrigation/Data/Localizations/jaJP.csv
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Localizations/jaJP.csv
@@ -2,27 +2,17 @@ ID,Text,Comment
 Knatte.WE_IrrigationExtractFuel.DisplayName,Irrigation With Tree boost,
 Knatte.WE_IrrigationFuel.DisplayName,Irrigation,
 Knatte.IrrigationTower.DisplayName,Irrigation Tower,-
-Knatte.IrrigationTower.Description,"Irrigates land around it.
-Does not use water for tiles that it can't Irrigate
-Max range: 7",
+Knatte.IrrigationTower.Description,"Irrigates land around it.",
 Knatte.IrrigationTower.Header,Irrigation Mode:,untranslated
 Knatte.IrrigationTower.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
 Knatte.IrrigationTowerV2_FT.DisplayName,Efficient Irrigation Tower,-
-Knatte.IrrigationTowerV2_FT.Description,"Irrigates More land around it and can boost tree and plant growth with extract.
-Does not use water for tiles that it can't Irrigate 
-Max range: 15",
+Knatte.IrrigationTowerV2_FT.Description,"Irrigates more land around it and can boost tree and plant growth with extract.",
 Knatte.IrrigationTowerV2_IT.DisplayName,Powered Irrigation Tower,-
-Knatte.IrrigationTowerV2_IT.Description,"Irrigates around it without any worker needed. For more Water usage it also blocks contamination.
-Does not use water for tiles that it can't Irrigate 
-Max range: 17",
+Knatte.IrrigationTowerV2_IT.Description,"Irrigates land around it without workers and can block contamination.",
 Knatte.IrrigationTowerV2.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
 Knatte.BigIrrigationTower.DisplayName,Big Irrigation Tower,-
-Knatte.BigIrrigationTowerIT.Description,"Irrigates even More land around it for less Water. 
-Pipes is the starting point of irrigation.
-Does not use water for tiles that it cant Irrigate
-Max range: 40",
-Knatte.BigIrrigationTowerFT.Description,"Irrigates even More land around it for less Water. 
-Pipes is the starting point of irrigation. 
-Does not use water for tiles that it cant Irrigate
-Max range: 40",
+Knatte.BigIrrigationTowerIT.Description,"Irrigates even more land around it with less water.
+Pipes are the starting point of irrigation.",
+Knatte.BigIrrigationTowerFT.Description,"Irrigates even more land around it with less water.
+Pipes are the starting point of irrigation.",
 Knatte.BigIrrigationTower.FlavorDescription,あぶくたった　煮えたった　トントントン\n何の音？　水が滴り落ちる音！,-原文の「Drip Drip Drop」はハンカチ落としに似た海外の遊びで、ハンカチを落とす代わりに水を頭にかける。

--- a/Assets/Mods/Water Extention_Irrigation/Data/Localizations/jaJP.csv
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Localizations/jaJP.csv
@@ -6,13 +6,13 @@ Knatte.IrrigationTower.Description,"Irrigates land around it.",
 Knatte.IrrigationTower.Header,Irrigation Mode:,untranslated
 Knatte.IrrigationTower.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
 Knatte.IrrigationTowerV2_FT.DisplayName,Efficient Irrigation Tower,-
-Knatte.IrrigationTowerV2_FT.Description,"Irrigates more land around it and can boost tree and plant growth with extract.",
+Knatte.IrrigationTowerV2_FT.Description,"Irrigates More land around it and can boost tree and plant growth with extract.",
 Knatte.IrrigationTowerV2_IT.DisplayName,Powered Irrigation Tower,-
-Knatte.IrrigationTowerV2_IT.Description,"Irrigates land around it without workers and can block contamination.",
+Knatte.IrrigationTowerV2_IT.Description,"Irrigates around it without any worker needed. For more Water usage it also blocks contamination.",
 Knatte.IrrigationTowerV2.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
 Knatte.BigIrrigationTower.DisplayName,Big Irrigation Tower,-
-Knatte.BigIrrigationTowerIT.Description,"Irrigates even more land around it with less water.
-Pipes are the starting point of irrigation.",
-Knatte.BigIrrigationTowerFT.Description,"Irrigates even more land around it with less water.
-Pipes are the starting point of irrigation.",
+Knatte.BigIrrigationTowerIT.Description,"Irrigates even More land around it for less Water.
+Pipes is the starting point of irrigation.",
+Knatte.BigIrrigationTowerFT.Description,"Irrigates even More land around it for less Water.
+Pipes is the starting point of irrigation.",
 Knatte.BigIrrigationTower.FlavorDescription,あぶくたった　煮えたった　トントントン\n何の音？　水が滴り落ちる音！,-原文の「Drip Drip Drop」はハンカチ落としに似た海外の遊びで、ハンカチを落とす代わりに水を頭にかける。

--- a/Assets/Mods/Water Extention_Irrigation/Data/Localizations/ruRU.csv
+++ b/Assets/Mods/Water Extention_Irrigation/Data/Localizations/ruRU.csv
@@ -1,28 +1,18 @@
 ID,Text,Comment
-Knatte.WE_IrrigationExtractFuel.DisplayName,Irrigation With Tree boost,
-Knatte.WE_IrrigationFuel.DisplayName,Irrigation,
-Knatte.IrrigationTower.DisplayName,Irrigation Tower,-
-Knatte.IrrigationTower.Description,"Irrigates land around it.
-Does not use water for tiles that it can't Irrigate
-Max range: 7",
-Knatte.IrrigationTower.Header,Irrigation Mode:,untranslated
-Knatte.IrrigationTower.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
-Knatte.IrrigationTowerV2_FT.DisplayName,Efficient Irrigation Tower,-
-Knatte.IrrigationTowerV2_FT.Description,"Irrigates More land around it and can boost tree and plant growth with extract.
-Does not use water for tiles that it can't Irrigate 
-Max range: 15",
-Knatte.IrrigationTowerV2_IT.DisplayName,Powered Irrigation Tower,-
-Knatte.IrrigationTowerV2_IT.Description,"Irrigates around it without any worker needed. For more Water usage it also blocks contamination.
-Does not use water for tiles that it can't Irrigate 
-Max range: 17",
-Knatte.IrrigationTowerV2.FlavorDescription,"With less than a third of Earth covered in water, irrigation became a must.",The game is set on Earth turned into a dry wasteland.
-Knatte.BigIrrigationTower.DisplayName,Big Irrigation Tower,-
-Knatte.BigIrrigationTowerIT.Description,"Irrigates even More land around it for less Water. 
-Pipes is the starting point of irrigation.
-Does not use water for tiles that it cant Irrigate
-Max range: 40",
-Knatte.BigIrrigationTowerFT.Description,"Irrigates even More land around it for less Water. 
-Pipes is the starting point of irrigation. 
-Does not use water for tiles that it cant Irrigate
-Max range: 40",
-Knatte.BigIrrigationTower.FlavorDescription,Drip Drip Drop.,
+Knatte.WE_IrrigationExtractFuel.DisplayName,Орошение с ускорением роста,
+Knatte.WE_IrrigationFuel.DisplayName,Орошение,
+Knatte.IrrigationTower.DisplayName,Оросительная башня,-
+Knatte.IrrigationTower.Description,"Орошает землю вокруг себя.",
+Knatte.IrrigationTower.Header,Режим орошения:,untranslated
+Knatte.IrrigationTower.FlavorDescription,"Когда меньше трети Земли покрыто водой, без орошения уже не обойтись.",The game is set on Earth turned into a dry wasteland.
+Knatte.IrrigationTowerV2_FT.DisplayName,Улучшенная оросительная башня,-
+Knatte.IrrigationTowerV2_FT.Description,"Орошает больше земли вокруг себя и может ускорять рост деревьев и растений с помощью экстракта.",
+Knatte.IrrigationTowerV2_IT.DisplayName,Механическая оросительная башня,-
+Knatte.IrrigationTowerV2_IT.Description,"Орошает землю вокруг себя без работников и может блокировать загрязнение.",
+Knatte.IrrigationTowerV2.FlavorDescription,"Когда меньше трети Земли покрыто водой, без орошения уже не обойтись.",The game is set on Earth turned into a dry wasteland.
+Knatte.BigIrrigationTower.DisplayName,Большая оросительная башня,-
+Knatte.BigIrrigationTowerIT.Description,"Орошает еще больше земли вокруг себя, расходуя меньше воды.
+Трубы служат началом зоны орошения.",
+Knatte.BigIrrigationTowerFT.Description,"Орошает еще больше земли вокруг себя, расходуя меньше воды.
+Трубы служат началом зоны орошения.",
+Knatte.BigIrrigationTower.FlavorDescription,Кап-кап-кап.,


### PR DESCRIPTION
This updates Water Extention irrigation tower data for Timberborn 1.1 UI support.

Changes:
- updates big irrigation tower driveway specs from the old single DrivewayModelSpec format to the Timberborn 1.1 DrivewayModelsSpec format
- trims duplicated technical details from irrigation tower building descriptions

TimberCommons now shows irrigation efficiency, maximum range, and effects in the building UI, so the localization descriptions no longer need to repeat water-efficiency and max-range details.

This PR intentionally does not update manifest or changelog files.